### PR TITLE
Adding snapshot-iPad.js to list of files to copy

### DIFF
--- a/lib/fastlane/setup.rb
+++ b/lib/fastlane/setup.rb
@@ -37,7 +37,7 @@ module Fastlane
     end
 
     def files_to_copy
-      ['Deliverfile', 'Snapfile', 'deliver', 'snapshot.js', 'SnapshotHelper.js', 'screenshots']
+      ['Deliverfile', 'Snapfile', 'deliver', 'snapshot.js', 'snapshot-iPad.js', 'SnapshotHelper.js', 'screenshots']
     end
 
     def copy_existing_files


### PR DESCRIPTION
According to https://github.com/KrauseFx/snapshot/blob/460b45753d400d2e3d3a38ddb529e63805764e23/lib/snapshot/snapfile_creator.rb#L12 `snapshot-iPad.js` is also a file created by KrauseFx/snapshot .